### PR TITLE
`docker-compose` is deprecated. We should use `docker compose`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ bash generate-certs-hot-warm.sh
 Adjust `Xms/Xmx` parameters and start the cluster :
 
 ```bash
-docker compose -f docker compose.hot-warm.yml up -d
+docker compose -f docker-compose.hot-warm.yml up -d
 ```
 
 Wait about 60 seconds and run `securityadmin` to initialize the security plugin :

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ bash generate-certs.sh
 Start the cluster :
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Wait about 30 seconds and run `securityadmin` to initialize the security plugin :
 
 ```bash
-docker-compose exec os01 bash -c "chmod +x plugins/opensearch-security/tools/securityadmin.sh && bash plugins/opensearch-security/tools/securityadmin.sh -cd config/opensearch-security -icl -nhnv -cacert config/certificates/ca/ca.pem -cert config/certificates/ca/admin.pem -key config/certificates/ca/admin.key -h localhost"
+docker compose exec os01 bash -c "chmod +x plugins/opensearch-security/tools/securityadmin.sh && bash plugins/opensearch-security/tools/securityadmin.sh -cd config/opensearch-security -icl -nhnv -cacert config/certificates/ca/ca.pem -cert config/certificates/ca/admin.pem -key config/certificates/ca/admin.key -h localhost"
 ```
 
 > Find all the configuration files in the container's `/usr/share/opensearch/config/opensearch-security` directory. You might want to [mount them as volumes](https://opendistro.github.io/for-elasticsearch-docs/docs/install/docker-security/).
@@ -75,13 +75,13 @@ bash generate-certs-hot-warm.sh
 Adjust `Xms/Xmx` parameters and start the cluster :
 
 ```bash
-docker-compose -f docker-compose.hot-warm.yml up -d
+docker compose -f docker compose.hot-warm.yml up -d
 ```
 
 Wait about 60 seconds and run `securityadmin` to initialize the security plugin :
 
 ```bash
-docker-compose exec os01 bash -c "chmod +x plugins/opensearch-security/tools/securityadmin.sh && bash plugins/opensearch-security/tools/securityadmin.sh -cd config/opensearch-security -icl -nhnv -cacert config/certificates/ca/ca.pem -cert config/certificates/ca/admin.pem -key config/certificates/ca/admin.key -h localhost"
+docker compose exec os01 bash -c "chmod +x plugins/opensearch-security/tools/securityadmin.sh && bash plugins/opensearch-security/tools/securityadmin.sh -cd config/opensearch-security -icl -nhnv -cacert config/certificates/ca/ca.pem -cert config/certificates/ca/admin.pem -key config/certificates/ca/admin.key -h localhost"
 ```
 
 > Find all the configuration files in the container's `/usr/share/opensearch/config/opensearch-security` directory. You might want to [mount them as volumes](https://opendistro.github.io/for-elasticsearch-docs/docs/install/docker-security/).


### PR DESCRIPTION
`docker-compose` is deprecated. We should use `docker compose`.