### PR TITLE
Upgrade OpenSearch and Dashboards from 3.4.0 to 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenSearch - Docker - Compose
 
-![OpenSearch version](https://img.shields.io/badge/OpenSearch%20version-3.4.0-blue)
+![OpenSearch version](https://img.shields.io/badge/OpenSearch%20version-3.7.0-blue)
 
 Dockerized cluster architecture for OpenSearch with compose.
 

--- a/docker-compose.hot-warm.yml
+++ b/docker-compose.hot-warm.yml
@@ -8,7 +8,7 @@ services:
   # Needs : heavy CPU, medium memory
   os00:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os00
@@ -51,7 +51,7 @@ services:
   # Needs : low CPU, low memory
   os01:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os01
@@ -90,7 +90,7 @@ services:
   # Needs : medium CPU, heavy memory, high-speed storage
   os02:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os02
@@ -129,7 +129,7 @@ services:
   # Needs : medium CPU, heavy memory, high-speed storage
   os03:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os03
@@ -168,7 +168,7 @@ services:
   # Needs : medium CPU, heavy memory, high-speed storage
   os04:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os04
@@ -205,7 +205,7 @@ services:
   # Needs : lower-speed CPU, heavy memory, lower-speed storage
   os05:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os05
@@ -242,7 +242,7 @@ services:
   # Needs : lower-speed CPU, heavy memory, lower-speed storage
   os06:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os06
@@ -279,7 +279,7 @@ services:
   # Needs : lower-speed CPU, heavy memory, lower-speed storage
   os07:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os07
@@ -311,7 +311,7 @@ services:
   
   kibana:
     restart: always
-    image: opensearchproject/opensearch-dashboards:3.4.0
+    image: opensearchproject/opensearch-dashboards:3.7.0
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   os01:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os01
@@ -35,7 +35,7 @@ services:
   
   os02:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os02
@@ -65,7 +65,7 @@ services:
   
   os03:
     restart: always
-    image: opensearchproject/opensearch:3.4.0
+    image: opensearchproject/opensearch:3.7.0
     environment:
       OPENSEARCH_JAVA_OPTS: "-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       node.name: os03
@@ -95,7 +95,7 @@ services:
 
   kibana:
     restart: always
-    image: opensearchproject/opensearch-dashboards:3.4.0
+    image: opensearchproject/opensearch-dashboards:3.7.0
     environment:
       OPENSEARCH_HOSTS: '["https://os01:9200","https://os02:9200","https://os03:9200"]' # must be a string with no spaces when specified as an environment variable
       DISABLE_INSTALL_DEMO_CONFIG: "true"


### PR DESCRIPTION
## Summary

Upgrades OpenSearch and OpenSearch Dashboards from **3.4.0** to **3.7.0** (latest 3.x release, June 2026). The project was three minor versions behind (3.5.0, 3.6.0, 3.7.0 all released since 3.4.0).

## Changes

Bumped all `3.4.0` image tags and the README badge to `3.7.0` (14 references total):

- **`docker-compose.yml`** — 3 `opensearch` nodes + 1 `opensearch-dashboards`
- **`docker-compose.hot-warm.yml`** — 8 `opensearch` nodes (os00–os07) + 1 `opensearch-dashboards`
- **`README.md`** — version badge

## Notes

- No reindexing required: this is an in-line upgrade within the 3.x line, so the README's 2.x→3.x reindex caveat does not apply.
- Both `opensearchproject/opensearch:3.7.0` and `opensearchproject/opensearch-dashboards:3.7.0` are published and active on Docker Hub.

## Verification

- `grep -rn "3.4.0"` returns no matches; all references now point to `3.7.0`.
- Compose files still parse with `docker compose config`.